### PR TITLE
Prevent stale computations from being run

### DIFF
--- a/lib/both/routes.js
+++ b/lib/both/routes.js
@@ -26,6 +26,18 @@ var fadminRoutes = FlowRouter.group({
       Session.set('admin_id',null);
       Session.set('admin_doc', null);
     }
+  ],
+  triggersExit: [
+	function(context) {
+		/* Force displaying the loading template when a route
+		 * is left in order to prevent the setting of session
+		 * variables, in the Enter Triggers, from rerunning
+		 * computations in the currently displayed template
+		 * (which is going to be evicted anyway)
+		 */
+		BlazeLayout.render('fAdminLayout', {main: 'AdminLoading'});
+		Tracker.flush();
+	}
   ]
 });
 
@@ -53,11 +65,6 @@ fadminRoutes.route('/view/:collectionName',{
 		Session.set('admin_collection_page', 'view');
 		Session.set('admin_collection_name', context.params.collectionName);
 	}],
-	triggersExit: [
-		function(context){
-			BlazeLayout.render('fAdminLayout',{main: 'AdminLoading'});
-		}
-	],
 	action: function(params)
 	{
 		BlazeLayout.render('fAdminLayout',{main: 'AdminDashboardView'});
@@ -71,11 +78,6 @@ fadminRoutes.route('/new/:collectionName',{
 		Session.set('admin_collection_page', 'new');
 		Session.set('admin_collection_name', context.params.collectionName);
 	}],
-	triggersExit: [
-		function(context){
-			BlazeLayout.render('fAdminLayout',{main: 'AdminLoading'});
-		}
-	],
 	action: function(params)
 	{	if(params.collectionName == 'Users')
 			BlazeLayout.render('fAdminLayout',{main: 'AdminDashboardUsersNew'});
@@ -98,7 +100,6 @@ fadminRoutes.route('/edit/:collectionName/:_id',{
 	}],
 	triggersExit: [
 		function(context){
-			BlazeLayout.render('fAdminLayout',{main: 'AdminLoading'});
 			Session.set('admin_id',null);
 		}
 	],


### PR DESCRIPTION
Add a 'triggersExit' function to all admin routes
that switches the currently displayed content to
the loading screen.

The Tracker is then flushed to update the view,
evict the current content and force it to stop
its computations.

This allows to change the session variables in
the 'tiggersEnter' and 'action' functions without
running computations not prepared to work with the
new values.

Fixes #19