### PR TITLE
Removing erroneous API version restriction

### DIFF
--- a/lib/client/html/admin_sidebar.html
+++ b/lib/client/html/admin_sidebar.html
@@ -25,9 +25,9 @@
 				{{/each}}
 				{{#each admin_sidebar_items}}
 					{{#if options.urls}}
-						{{> adminSidebarItemTree}} -->
+						{{> adminSidebarItemTree}} 
 					{{else}}
-						{{> adminSidebarItem}} -->
+						{{> adminSidebarItem}}
 					{{/if}}
 				{{/each}}
 			</ul>

--- a/package.js
+++ b/package.js
@@ -11,7 +11,6 @@ Package.describe({
 });
 
 Package.onUse(function(api) {
-  api.versionsFrom('1.3');
 
   both = ['client','server']
 


### PR DESCRIPTION
The API restriction forces the packages to be fixed to the version used in the stated release of the Meteor API. Pegging to 1.3 restricts users from being able to upgrade to newer versions of Meteor and newer versions of other packages, but there is no issue with this package that requires this. 