### PR TITLE
Removing trailing --> on custom sidebar items.

### DIFF
--- a/lib/client/html/admin_sidebar.html
+++ b/lib/client/html/admin_sidebar.html
@@ -25,9 +25,9 @@
 				{{/each}}
 				{{#each admin_sidebar_items}}
 					{{#if options.urls}}
-						{{> adminSidebarItemTree}} -->
+						{{> adminSidebarItemTree}} 
 					{{else}}
-						{{> adminSidebarItem}} -->
+						{{> adminSidebarItem}}
 					{{/if}}
 				{{/each}}
 			</ul>


### PR DESCRIPTION
Custom sidebar items have a "-->" trailing them. Removing what appears to be leftover comment closing tag. 